### PR TITLE
[semver:patch] publish: fix JSON arg (manifest)

### DIFF
--- a/src/commands/publish.yml
+++ b/src/commands/publish.yml
@@ -26,7 +26,7 @@ steps:
         time="$(git show --no-patch --format=%cI)"
         data="$(jq \
           --null-input \
-          --arg manifest "$manifest" \
+          --argjson manifest "$manifest" \
           --arg time "$time" \
           --arg version "<< parameters.version >>" \
           --arg ci_url "$CIRCLE_BUILD_URL" \


### PR DESCRIPTION
The value of `$manifest` is a JSON string. It should be sent as nested JSON data, but with `--arg` it is escaped and transmitted as a string.