### PR TITLE
[semver:patch] publish: fix vcs url

### DIFF
--- a/src/commands/publish.yml
+++ b/src/commands/publish.yml
@@ -30,7 +30,7 @@ steps:
           --arg time "$time" \
           --arg version "<< parameters.version >>" \
           --arg ci_url "$CIRCLE_BUILD_URL" \
-          --arg vcs_url "${CIRCLE_REPOSITORY_URL}/commit/${CIRCLE_SHA1:0:7}" \
+          --arg vcs_url "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1:0:7}" \
           '{appManifest: $manifest, commitTime: $time, version: $version, metadata: {ciBuildUrl: $ci_url, commitUrl: $vcs_url}}'
         )"
 


### PR DESCRIPTION
`CIRCLE_REPOSITORY_URL` is a git URL (`git@...`). Instead, this constructs the HTTP URL directly, since I couldn't find a suitable [built-in](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables). 