### PR TITLE
[semver:patch] replace curl w/ wget for SONAR API calls

### DIFF
--- a/src/commands/publish.yml
+++ b/src/commands/publish.yml
@@ -34,11 +34,11 @@ steps:
           '{appManifest: $manifest, commitTime: $time, version: $version, metadata: {ciBuildUrl: $ci_url, commitUrl: $vcs_url}}'
         )"
 
-        curl \
-          --silent \
-          --show-error \
-          --fail \
+        wget \
+          --no-verbose \
+          --content-on-error \
+          --output-file - \
           --header "Authorization: Bearer ${<< parameters.token-variable >>}" \
           --header "Content-Type: application/json" \
-          --data "$data" \
+          --post-data "$data" \
           "<< parameters.api-url >>/packages?appName=${app}"

--- a/src/commands/validate.yml
+++ b/src/commands/validate.yml
@@ -20,11 +20,11 @@ steps:
       command: |-
         data="$(yq eval '<< parameters.manifest-path >>' --tojson | jq '{content: .}')"
 
-        curl \
-          --silent \
-          --show-error \
-          --fail \
+        wget \
+          --no-verbose \
+          --content-on-error \
+          --output-file - \
           --header "Authorization: Bearer ${<< parameters.token-variable >>}" \
           --header "Content-Type: application/json" \
-          --data "$data" \
+          --post-data "$data" \
           "<< parameters.api-url >>/schema/validate"


### PR DESCRIPTION
`curl --fail` immediately exits once a >=400 status header is received. Curl just added support for printing the body as well:

https://daniel.haxx.se/blog/2021/02/11/curl-fail-with-body/

However, this version is brand new and not even present on the download page, let alone in package managers. `wget` has had this option for much longer, as `--content-on-error`.

This ensures that the full JSON error response will be printed.